### PR TITLE
Fix force_rewrite bug

### DIFF
--- a/hypatia/core/main.py
+++ b/hypatia/core/main.py
@@ -20,6 +20,7 @@ from hypatia.analysis.postprocessing import (
     dict_to_csv,
 )
 import os
+import shutil
 import pandas as pd
 
 import logging
@@ -88,7 +89,7 @@ class Model:
                     f" the parameter files, use force_rewrite=True."
                 )
             else:
-                os.rmdir(path)
+                shutil.rmtree(path)
 
         os.mkdir(path)
         self._StrData._write_input_excel(path)
@@ -245,7 +246,7 @@ class Model:
         regions_sheet = pd.DataFrame(regions_property,
             index=self._StrData.glob_mapping["Regions"]["Region"],
         )
-        
+
         emissions_sheet = self._StrData.glob_mapping['Emissions'].set_index(['Emission'],inplace=False)
         emissions_sheet = pd.DataFrame(
             emissions_sheet.values,


### PR DESCRIPTION
**TLDR**

The create_data_excels has a flag called force_rewrite, which should allow to overwrite the parameters folder if it already exist. This currently doesn't seem to work if the parameters folder that needs to be overwritten is not empty (which is most likely never the case).

**THE BUG**
This bug is caused by the fact that *os.rmdir(path)* will throw an exception if it is used to remove an non-empty folder.
This stack overflow post has some more info on that: https://stackoverflow.com/questions/6996603/how-to-delete-a-file-or-folder-in-python
The solution is to use *shutil.rmtree()* instead. 

**REPRO**

I tested the change using the following script
```
from hypatia import Model
model = Model(path=".../Utopia2_planning_single_node_DN/sets/", mode="Planning")
model.create_data_excels("...Utopia2_planning_single_node_DN/parameters_/", force_rewrite=True)
model.create_data_excels("...Utopia2_planning_single_node_DN/parameters_/", force_rewrite=True)
```

If I run this script before the change I get
```
(venv) afa@afa-mbp Hypatia % python3 repro.py
Traceback (most recent call last):
  File "repro.py", line 4, in <module>
    model.create_data_excels("/Users/afa/Desktop/Hypatia/examples/Utopia2_planning_single_node_DN/parameters_test2/", force_rewrite=True)
  File "/Users/afa/Desktop/Hypatia/hypatia/core/main.py", line 91, in create_data_excels
    os.rmdir(path)
OSError: [Errno 66] Directory not empty: '/Users/afa/Desktop/Hypatia/examples/Utopia2_planning_single_node_DN/parameters_test2/'
(
```

After the change I get no exception

