### PR TITLE
Add helper to create technology columns

### DIFF
--- a/hypatia/backend/StrData.py
+++ b/hypatia/backend/StrData.py
@@ -559,48 +559,25 @@ class ReadSets:
             # Creates the columns of the technology-specific parameter files
             # based on the technology categories and the technologies within each
             # caregory
-            dict_ = self.Technologies[reg]
-            level1 = []
-            level2 = []
-            for key, values in dict_.items():
-                if key != "Demand":
-                    for value in values:
-                        level1.append(key)
-                        level2.append(value)
-
-            indexer_reg[reg] = pd.MultiIndex.from_arrays(
-                [level1, level2], names=["Tech_category", "Technology"]
+            indexer_reg[reg] = create_technology_columns(
+                self.Technologies[reg],
+                ignored_tech_categories=["Demand"],
             )
 
-            if "Storage" in self.Technologies[reg].keys():
+            indexer_reg_drop1[reg] = create_technology_columns(
+                self.Technologies[reg],
+                ignored_tech_categories=["Demand", "Storage"],
+            )
 
-                indexer_reg_drop1[reg] = indexer_reg[reg].drop("Storage", level=0)
+            indexer_reg_drop2[reg] = create_technology_columns(
+                self.Technologies[reg],
+                ignored_tech_categories=["Demand", "Storage", "Transmission"],
+            )
 
-            else:
-
-                indexer_reg_drop1[reg] = indexer_reg[reg]
-
-            if "Transmission" in self.Technologies[reg].keys():
-
-                indexer_reg_drop2[reg] = indexer_reg_drop1[reg].drop(
-                    "Transmission", level=0
-                )
-
-            else:
-
-                indexer_reg_drop2[reg] = indexer_reg_drop1[reg]
-
-            level1_ = level1 * 2
-            level2_ = level2 * 2
-            tax = []
-            sub = []
-            for tech in level2:
-                tax.append("Tax")
-                sub.append("Sub")
-            taxsub = tax + sub
-            add_indexer[reg] = pd.MultiIndex.from_arrays(
-                [taxsub, level1_, level2_],
-                names=["Taxes or Subsidies", "Tech_category", "Technology"],
+            add_indexer[reg] = create_technology_columns(
+                self.Technologies[reg],
+                ignored_tech_categories=["Demand"],
+                additional_level=("Taxes or Subsidies", ["Tax", "Sub"])
             )
 
             self.regional_sheets_ids[reg] = {
@@ -1086,3 +1063,60 @@ class ReadSets:
         else:
 
             self._mode = var
+
+"""
+A helper function used in ReadSets to initialize the column field
+of technology-specific parameter files
+
+Parameters
+----------
+technologies_hierarchy : Dict[str => List[Str]]
+    A dictionary defining the mapping between a technology category
+    and a list of technologies belonging to that category.
+    i.e. {"Supply": ["NG_extraction", "Geo_PP"]}
+
+ignored_tech_categories : List[str]
+    A list of technology categories that should be excluded from
+    the parameter's file columns
+
+additional_level : None/Touple(str, List[str])
+    An additional top hierarchy level to be added to the columns.
+    It is in the form (column name, column values).
+    i.e. ("Taxes or Subsidies", ["Tax", "Sub"])
+"""
+def create_technology_columns(
+    technologies_hierarchy,
+    ignored_tech_categories=["Demand"],
+    additional_level=None,
+):
+    tuples = []
+    names = ["Tech_category", "Technology"]
+    for tech_category, technologies in technologies_hierarchy.items():
+        for technology in technologies:
+            tuples.append((tech_category, technology))
+
+    # Remove technologies of ignored categories
+    for ignored_tech_category in ignored_tech_categories:
+        if ignored_tech_category in technologies_hierarchy.keys():
+            tuples = [t for t in tuples if t[0] != ignored_tech_category]
+
+    # Add an additional top level if it was specified
+    if additional_level != None:
+        additional_level_name = additional_level[0]
+        additional_level_values = additional_level[1]
+
+        names.insert(0, additional_level_name)
+
+        new_tuples = []
+        for additional_level_value in additional_level_values:
+            for t in tuples:
+                l = list(t)
+                l.insert(0, additional_level_value)
+                new_tuples.append(tuple(l))
+        tuples = new_tuples
+
+    indexer = pd.MultiIndex.from_tuples(
+        tuples, names=names
+    )
+
+    return indexer

--- a/hypatia/backend/tests/StrDataTests.py
+++ b/hypatia/backend/tests/StrDataTests.py
@@ -1,0 +1,88 @@
+import pandas as pd
+import unittest
+from hypatia.backend.StrData import create_technology_columns
+
+'''
+Unit tests for the functions in StrData.py
+'''
+
+class TestCreateTechnologyColumns(unittest.TestCase):
+    technologies_hierarchy = {
+        "Supply": ["NG_extraction", "Geo_PP"],
+        "Conversion": ["Boiler"],
+        "Demand": ["Elec_demand", "Heat_demand"],
+    }
+
+    def test_create_technology_columns(self):
+        expected = pd.MultiIndex.from_arrays(
+                [
+                    ["Supply", "Supply", "Conversion", "Demand", "Demand"],
+                    ["NG_extraction", "Geo_PP", "Boiler", "Elec_demand", "Heat_demand"],
+                ],
+                names=["Tech_category", "Technology"]
+            )
+
+        self.assertTrue(
+            expected.equals(
+                create_technology_columns(self.technologies_hierarchy, ignored_tech_categories=[])
+            )
+        )
+
+    def test_create_technology_columns_ignore_tech(self):
+        # check ignoring demand is the default behavior
+        expected = pd.MultiIndex.from_arrays(
+                [
+                    ["Supply", "Supply", "Conversion"],
+                    ["NG_extraction", "Geo_PP", "Boiler"],
+                ],
+                names=["Tech_category", "Technology"]
+            )
+
+        self.assertTrue(
+            expected.equals(
+                create_technology_columns(self.technologies_hierarchy)
+            )
+        )
+
+
+        # check we can ignore multiple technologies
+        expected = pd.MultiIndex.from_arrays(
+                [
+                    ["Supply", "Supply"],
+                    ["NG_extraction", "Geo_PP"],
+                ],
+                names=["Tech_category", "Technology"]
+            )
+
+        self.assertTrue(
+            expected.equals(
+                create_technology_columns(
+                    self.technologies_hierarchy,
+                    ignored_tech_categories=["Demand", "Conversion"]
+                )
+            )
+        )
+
+    def test_create_technology_columns_add_layer(self):
+        # check we can correctly add an additional top layer
+        expected = pd.MultiIndex.from_arrays(
+                [
+                    ["Tax", "Tax", "Tax", "Sub", "Sub", "Sub"],
+                    ["Supply", "Supply", "Conversion", "Supply", "Supply", "Conversion"],
+                    ["NG_extraction", "Geo_PP", "Boiler", "NG_extraction", "Geo_PP", "Boiler"],
+                ],
+                names=["Taxes or Subsidies", "Tech_category", "Technology"]
+            )
+
+        self.assertTrue(
+            expected.equals(
+                create_technology_columns(
+                    self.technologies_hierarchy,
+                    additional_level=("Taxes or Subsidies", ["Tax", "Sub"])
+                )
+            )
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### TLDR
This change creates a helper function in order to simplify the code that creates the columns of the technology-specific parameter files. I am doing this primarily because it helps simplify the upcoming change to add the ability to model multiple emissions types. 

### TESTS
**Unit tests**
```(venv) afa@afa-mbp Hypatia % python3 -m unittest hypatia/backend/tests/StrDataTests.py```

**Manual test**
In order to make sure that the new code behave exactly as the old code I run https://gist.github.com/AAmedeo/7002cb653b8bebd0f7629054fa430750 before and after this change and verified that the generated results don't change. 